### PR TITLE
Fix label query

### DIFF
--- a/pkg/frontend/querymiddleware/query_booster.go
+++ b/pkg/frontend/querymiddleware/query_booster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -125,7 +126,7 @@ type IsQueryBoostedResponse struct {
 }
 
 func queryBoostedMetric(query string) string {
-	return fmt.Sprintf(boostedQueryInternalQuery, queryBoosterMetric, boostedQueryLabelName, query, boostedQueryLabelName)
+	return fmt.Sprintf(boostedQueryInternalQuery, queryBoosterMetric, boostedQueryLabelName, strings.ReplaceAll(query, `"`, `\"`), boostedQueryLabelName)
 }
 
 const boostedQueryInternalQuery = `

--- a/pkg/frontend/querymiddleware/query_booster.go
+++ b/pkg/frontend/querymiddleware/query_booster.go
@@ -60,7 +60,7 @@ func (q *queryBoosterMiddleware) Do(ctx context.Context, req MetricsQueryRequest
 	}
 	level.Info(log).Log("msg", "query is boosted", "query", queryCleaned)
 
-	queryRewritten := q.queryBoostedMetric(queryCleaned)
+	queryRewritten := queryBoostedMetric(queryCleaned)
 	req, err = req.WithQuery(queryRewritten)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to rewrite boosted query")
@@ -124,7 +124,7 @@ type IsQueryBoostedResponse struct {
 	Infos     []string `json:"infos,omitempty"`
 }
 
-func (q *queryBoosterMiddleware) queryBoostedMetric(query string) string {
+func queryBoostedMetric(query string) string {
 	return fmt.Sprintf(boostedQueryInternalQuery, queryBoosterMetric, boostedQueryLabelName, query, boostedQueryLabelName)
 }
 
@@ -135,11 +135,11 @@ label_replace(
     "__name__",
     "",
     "",
-    "",
+    ""
   ),
   "%s",
   "",
   "",
-  "",
+  ""
 )
 `

--- a/pkg/frontend/querymiddleware/query_booster.go
+++ b/pkg/frontend/querymiddleware/query_booster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -20,18 +19,18 @@ const (
 )
 
 type queryBoosterMiddleware struct {
-	downstream http.RoundTripper
 	logger     log.Logger
+	qfeAddress string
 
 	next MetricsQueryHandler
 }
 
-func newQueryBoosterMiddleware(downstream http.RoundTripper, logger log.Logger) MetricsQueryMiddleware {
+func newQueryBoosterMiddleware(cfg Config, logger log.Logger) MetricsQueryMiddleware {
 	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &queryBoosterMiddleware{
-			downstream: downstream,
 			logger:     logger,
 			next:       next,
+			qfeAddress: fmt.Sprintf("%s:%d", "localhost", cfg.QueryFrontendHttpListenPort),
 		}
 	})
 }
@@ -49,7 +48,7 @@ func (q *queryBoosterMiddleware) Do(ctx context.Context, req MetricsQueryRequest
 	}
 
 	queryCleaned := expr.String()
-	isQueryBoosted, err := q.isQueryBoosted(ctx, queryCleaned, req.GetHeaders())
+	isQueryBoosted, err := q.isQueryBoosted(ctx, queryCleaned)
 	if err != nil {
 		level.Warn(log).Log("msg", "failed to check if query is boosted, running next middleware", "query", queryCleaned, "err", err)
 		return q.next.Do(ctx, req)
@@ -71,32 +70,29 @@ func (q *queryBoosterMiddleware) Do(ctx context.Context, req MetricsQueryRequest
 	return q.next.Do(ctx, req)
 }
 
-func (q *queryBoosterMiddleware) isQueryBoosted(ctx context.Context, query string, headers []*PrometheusHeader) (bool, error) {
+func (q *queryBoosterMiddleware) isQueryBoosted(ctx context.Context, query string) (bool, error) {
 	log, _ := spanlogger.NewWithLogger(ctx, q.logger, "queryBoosterMiddleware.isQueryBoosted")
 	defer log.Span.Finish()
-
-	boostedQueryResultsMetricMatcher := make(url.Values)
-	boostedQueryResultsMetricMatcher.Add("match[]", "__name__=\""+queryBoosterMetric+"\"")
-	boostedQueryResultsMetricMatcher.Add("match[]", boostedQueryLabelName+"=\""+query+"\"")
 
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
-		"/prometheus/api/v1/label/"+boostedQueryLabelName+"/values",
+		fmt.Sprintf("http://%s/prometheus/api/v1/labels", q.qfeAddress),
 		http.NoBody,
 	)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to create isQueryBoosted request")
 	}
 
-	req.URL.RawQuery = boostedQueryResultsMetricMatcher.Encode()
-	req.RequestURI = req.URL.String()
+	params := req.URL.Query()
+	params.Add("match[]", fmt.Sprintf(`{__name__="%s", %s="%s"}`, queryBoosterMetric, boostedQueryLabelName, query))
+	req.URL.RawQuery = params.Encode()
 
 	if err := user.InjectOrgIDIntoHTTPRequest(ctx, req); err != nil {
 		return false, errors.Wrap(err, "failed to inject org ID into isQueryBoosted request")
 	}
 
-	respEncoded, err := q.downstream.RoundTrip(req)
+	respEncoded, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -110,7 +106,9 @@ func (q *queryBoosterMiddleware) isQueryBoosted(ctx context.Context, query strin
 		return false, errors.New("no success when querying whether isQueryBoosted")
 	}
 
-	if len(respDecoded.Data) > 0 && respDecoded.Data[0] == query {
+	// The matchers in the labels request already target the boosted series, so if we
+	// get a non-empty response we know the metric has a booster recording rule.
+	if len(respDecoded.Data) > 0 {
 		return true, nil
 	}
 

--- a/pkg/frontend/querymiddleware/query_booster.go
+++ b/pkg/frontend/querymiddleware/query_booster.go
@@ -86,7 +86,7 @@ func (q *queryBoosterMiddleware) isQueryBoosted(ctx context.Context, query strin
 	}
 
 	params := req.URL.Query()
-	params.Add("match[]", fmt.Sprintf(`{__name__="%s", %s="%s"}`, queryBoosterMetric, boostedQueryLabelName, query))
+	params.Add("match[]", fmt.Sprintf(`{__name__="%s", %s="%s"}`, queryBoosterMetric, boostedQueryLabelName, strings.ReplaceAll(query, `"`, `\"`)))
 	req.URL.RawQuery = params.Encode()
 
 	if err := user.InjectOrgIDIntoHTTPRequest(ctx, req); err != nil {

--- a/pkg/frontend/querymiddleware/query_booster_test.go
+++ b/pkg/frontend/querymiddleware/query_booster_test.go
@@ -1,13 +1,15 @@
 package querymiddleware
 
 import (
+	"fmt"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func Test_queryBoosterMiddleware_queryBoostedMetric(t *testing.T) {
-	q := queryBoostedMetric("sum(rate(cortex_query_frontend_queries_total[1m]))")
+	q := queryBoostedMetric(`sum(rate(cortex_query_frontend_queries_total{container="query-frontend"}[1m]))`)
+	fmt.Println(q)
 	_, err := parser.ParseExpr(q)
 	assert.NoError(t, err)
 }

--- a/pkg/frontend/querymiddleware/query_booster_test.go
+++ b/pkg/frontend/querymiddleware/query_booster_test.go
@@ -1,0 +1,13 @@
+package querymiddleware
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_queryBoosterMiddleware_queryBoostedMetric(t *testing.T) {
+	q := queryBoostedMetric("sum(rate(cortex_query_frontend_queries_total[1m]))")
+	_, err := parser.ParseExpr(q)
+	assert.NoError(t, err)
+}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -730,6 +730,8 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 
 	engineOpts, _, engineExperimentalFunctionsEnabled := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, promqlEngineRegisterer)
 
+	t.Cfg.Frontend.QueryMiddleware.QueryFrontendHttpListenPort = t.Cfg.Server.HTTPListenPort
+
 	tripperware, err := querymiddleware.NewTripperware(
 		t.Cfg.Frontend.QueryMiddleware,
 		util_log.Logger,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This makes an HTTP query to `http://localhost:<port>/prometheus/api/v1/labels` to target the query frontend directly (instead of dispatching it to the downstream range/instant query middlewares).

It also fixes some escaping issues.

(I don't have permission to push to this repo so I forked).

<details>
<summary>Query logs</summary>

```
ts=2024-08-03T11:13:06.336537591Z caller=handler.go:382 level=info user=anonymous traceID=06ddbf2e931f3f7e msg="query stats" component=query-frontend method=GET path=/prometheus/api/v1/labels route_name=prometheus_api_v1_labels user_agent=Go-http-client/1.1 status_code=200 response_time=9.448083ms response_size_bytes=90 query_wall_time_seconds=0.008255167 fetched_series_count=0 fetched_chunk_bytes=0 fetched_chunks_count=0 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=5.0833e-05 param_match[]="{__name__=\"QUERY_BOOSTER\", __boosted_query__=\"sum(rate(cortex_query_frontend_queries_total[1m]))\"}" results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
2024-08-03T11:13:06.388506216Z ts=2024-08-03T11:13:06.336841175Z caller=spanlogger.go:111 method=queryBoosterMiddleware.Do user=anonymous trace_id=4f1dc0b8e4c419d8 caller=log.go:168 level=info msg="query is boosted" query=sum(rate(cortex_query_frontend_queries_total[1m]))
2024-08-03T11:13:06.388510716Z ts=2024-08-03T11:13:06.348204758Z caller=handler.go:382 level=info user=anonymous traceID=4f1dc0b8e4c419d8 msg="query stats" component=query-frontend method=POST path=/prometheus/api/v1/query_range route_name=prometheus_api_v1_query_range user_agent=Grafana/10.4.3 status_code=200 response_time=21.117834ms response_size_bytes=1756 query_wall_time_seconds=0.008463084 fetched_series_count=3 fetched_chunk_bytes=674 fetched_chunks_count=16 fetched_index_bytes=174 sharded_queries=0 split_queries=1 estimated_series_count=0 queue_time_seconds=3.0209e-05 param_end=2024-08-03T11:13:00Z param_query=sum(rate(cortex_query_frontend_queries_total[1m])) param_start=2024-08-03T10:13:00Z param_step=15000 length=1h1m0s time_since_min_time=1h1m6.32641655s time_since_max_time=6.32641655s results_cache_hit_bytes=311 results_cache_miss_bytes=848 header_cache_control= status=success
2024-08-03T11:13:06.388514466Z ts=2024-08-03T11:13:06.35836805Z caller=handler.go:382 level=info user=anonymous traceID=0fc9cbd5d31031f3 msg="query stats" component=query-frontend method=GET path=/prometheus/api/v1/labels route_name=prometheus_api_v1_labels user_agent=Go-http-client/1.1 status_code=200 response_time=7.809167ms response_size_bytes=90 query_wall_time_seconds=0.006802834 fetched_series_count=0 fetched_chunk_bytes=0 fetched_chunks_count=0 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=4.3334e-05 param_match[]="{__name__=\"QUERY_BOOSTER\", __boosted_query__=\"sum(rate(cortex_query_frontend_queries_total[1m]))\"}" results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
2024-08-03T11:13:06.388516758Z ts=2024-08-03T11:13:06.358629175Z caller=spanlogger.go:111 method=queryBoosterMiddleware.Do user=anonymous trace_id=783d03e66e0ab77c caller=log.go:168 level=info msg="query is boosted" query=sum(rate(cortex_query_frontend_queries_total[1m]))
2024-08-03T11:13:06.388518216Z ts=2024-08-03T11:13:06.362594633Z caller=handler.go:382 level=info user=anonymous traceID=783d03e66e0ab77c msg="query stats" component=query-frontend method=POST path=/prometheus/api/v1/query route_name=prometheus_api_v1_query user_agent=Grafana/10.4.3 status_code=200 response_time=12.476167ms response_size_bytes=121 query_wall_time_seconds=0.002708958 fetched_series_count=1 fetched_chunk_bytes=80 fetched_chunks_count=2 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=2.7833e-05 param_query=sum(rate(cortex_query_frontend_queries_total[1m])) param_time=2024-08-03T11:13:06.313Z length=1m0s time_since_min_time=1m0.0370938s time_since_max_time=37.0938ms results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
2024-08-03T11:13:06.389535966Z ts=2024-08-03T11:13:06.37136105Z caller=handler.go:382 level=info user=anonymous traceID=15d235954ac45ccd msg="query stats" component=query-frontend method=GET path=/prometheus/api/v1/labels route_name=prometheus_api_v1_labels user_agent=Go-http-client/1.1 status_code=200 response_time=7.298916ms response_size_bytes=60 query_wall_time_seconds=0.006417416 fetched_series_count=0 fetched_chunk_bytes=0 fetched_chunks_count=0 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=3.0666e-05 param_match[]="{__name__=\"QUERY_BOOSTER\", __boosted_query__=\"QUERY_BOOSTER\"}" results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
2024-08-03T11:13:06.389550966Z ts=2024-08-03T11:13:06.371552841Z caller=spanlogger.go:111 method=queryBoosterMiddleware.Do user=anonymous trace_id=6b08c20852231094 caller=log.go:168 level=info msg="query is not boosted" query=QUERY_BOOSTER
2024-08-03T11:13:06.389552883Z ts=2024-08-03T11:13:06.379239591Z caller=handler.go:382 level=info user=anonymous traceID=6b08c20852231094 msg="query stats" component=query-frontend method=POST path=/prometheus/api/v1/query_range route_name=prometheus_api_v1_query_range user_agent=Grafana/10.4.3 status_code=200 response_time=14.908042ms response_size_bytes=1855 query_wall_time_seconds=0.005634292 fetched_series_count=3 fetched_chunk_bytes=674 fetched_chunks_count=16 fetched_index_bytes=174 sharded_queries=0 split_queries=1 estimated_series_count=0 queue_time_seconds=3.1917e-05 param_query=QUERY_BOOSTER param_start=2024-08-03T10:13:00Z param_step=15000 param_end=2024-08-03T11:13:00Z length=1h5m0s time_since_min_time=1h5m6.3637353s time_since_max_time=6.3637353s results_cache_hit_bytes=411 results_cache_miss_bytes=948 header_cache_control= status=success
2024-08-03T11:13:06.488624175Z ts=2024-08-03T11:13:06.388365758Z caller=handler.go:382 level=info user=anonymous traceID=2c94c874d1814f32 msg="query stats" component=query-frontend method=GET path=/prometheus/api/v1/labels route_name=prometheus_api_v1_labels user_agent=Go-http-client/1.1 status_code=200 response_time=7.466333ms response_size_bytes=60 query_wall_time_seconds=0.006494791 fetched_series_count=0 fetched_chunk_bytes=0 fetched_chunks_count=0 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=2.1042e-05 param_match[]="{__name__=\"QUERY_BOOSTER\", __boosted_query__=\"QUERY_BOOSTER\"}" results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
2024-08-03T11:13:06.488651508Z ts=2024-08-03T11:13:06.388631425Z caller=spanlogger.go:111 method=queryBoosterMiddleware.Do user=anonymous trace_id=2c8331710780559a caller=log.go:168 level=info msg="query is not boosted" query=QUERY_BOOSTER
2024-08-03T11:13:06.488653675Z ts=2024-08-03T11:13:06.392236716Z caller=handler.go:382 level=info user=anonymous traceID=2c8331710780559a msg="query stats" component=query-frontend method=POST path=/prometheus/api/v1/query route_name=prometheus_api_v1_query user_agent=Grafana/10.4.3 status_code=200 response_time=11.71125ms response_size_bytes=220 query_wall_time_seconds=0.002568917 fetched_series_count=1 fetched_chunk_bytes=80 fetched_chunks_count=2 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=5.0167e-05 param_query=QUERY_BOOSTER param_time=2024-08-03T11:13:06.313Z length=5m0s time_since_min_time=5m0.067499758s time_since_max_time=67.499758ms results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
2024-08-03T11:13:06.488659966Z ts=2024-08-03T11:13:06.400467341Z caller=handler.go:382 level=info user=anonymous traceID=3566bda0cf2091e7 msg="query stats" component=query-frontend method=GET path=/prometheus/api/v1/labels route_name=prometheus_api_v1_labels user_agent=Go-http-client/1.1 status_code=200 response_time=6.873667ms response_size_bytes=60 query_wall_time_seconds=0.006072833 fetched_series_count=0 fetched_chunk_bytes=0 fetched_chunks_count=0 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=1.7625e-05 param_match[]="{__name__=\"QUERY_BOOSTER\", __boosted_query__=\"sum(rate(cortex_query_frontend_queries_total[1m])) + 0\"}" results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
2024-08-03T11:13:06.488701550Z ts=2024-08-03T11:13:06.400713425Z caller=spanlogger.go:111 method=queryBoosterMiddleware.Do user=anonymous trace_id=7c56321ac773878a caller=log.go:168 level=info msg="query is not boosted" query="sum(rate(cortex_query_frontend_queries_total[1m])) + 0"
2024-08-03T11:13:06.488704633Z ts=2024-08-03T11:13:06.434408216Z caller=handler.go:382 level=info user=anonymous traceID=7c56321ac773878a msg="query stats" component=query-frontend method=POST path=/prometheus/api/v1/query_range route_name=prometheus_api_v1_query_range user_agent=Grafana/10.4.3 status_code=200 response_time=40.614125ms response_size_bytes=2124 query_wall_time_seconds=0.298100917 fetched_series_count=9 fetched_chunk_bytes=2536 fetched_chunks_count=27 fetched_index_bytes=486 sharded_queries=16 split_queries=1 estimated_series_count=0 queue_time_seconds=0.000428166 param_query="sum(rate(cortex_query_frontend_queries_total[1m])) + 0" param_start=2024-08-03T10:13:00Z param_step=60000 param_end=2024-08-03T11:13:00Z length=1h1m0s time_since_min_time=1h1m6.393175341s time_since_max_time=6.393175341s results_cache_hit_bytes=1049 results_cache_miss_bytes=308 header_cache_control= status=success
2024-08-03T11:13:06.488711050Z ts=2024-08-03T11:13:06.444362508Z caller=handler.go:382 level=info user=anonymous traceID=3cd02a924864add1 msg="query stats" component=query-frontend method=GET path=/prometheus/api/v1/labels route_name=prometheus_api_v1_labels user_agent=Go-http-client/1.1 status_code=200 response_time=7.721917ms response_size_bytes=60 query_wall_time_seconds=0.006416875 fetched_series_count=0 fetched_chunk_bytes=0 fetched_chunks_count=0 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=2.4583e-05 param_match[]="{__name__=\"QUERY_BOOSTER\", __boosted_query__=\"sum(rate(cortex_query_frontend_queries_total[1m])) + 0\"}" results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
2024-08-03T11:13:06.488716758Z ts=2024-08-03T11:13:06.444607258Z caller=spanlogger.go:111 method=queryBoosterMiddleware.Do user=anonymous trace_id=2aee61347dee94ca caller=log.go:168 level=info msg="query is not boosted" query="sum(rate(cortex_query_frontend_queries_total[1m])) + 0"
2024-08-03T11:13:06.488721133Z ts=2024-08-03T11:13:06.456247258Z caller=handler.go:382 level=info user=anonymous traceID=2aee61347dee94ca msg="query stats" component=query-frontend method=POST path=/prometheus/api/v1/query route_name=prometheus_api_v1_query user_agent=Grafana/10.4.3 status_code=200 response_time=20.131167ms response_size_bytes=121 query_wall_time_seconds=0.07729379 fetched_series_count=3 fetched_chunk_bytes=208 fetched_chunks_count=3 fetched_index_bytes=0 sharded_queries=16 split_queries=0 estimated_series_count=0 queue_time_seconds=0.000889541 param_time=2024-08-03T11:13:06.313Z param_query="sum(rate(cortex_query_frontend_queries_total[1m])) + 0" length=1m0s time_since_min_time=1m0.123079675s time_since_max_time=123.079675ms results_cache_hit_bytes=0 results_cache_miss_bytes=0 header_cache_control= status=success
```

</details>

![image](https://github.com/user-attachments/assets/21d56235-bf5f-484b-addf-5af68621677f)


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
